### PR TITLE
Fixed bug where greenError and blueError were set wrong in IErrorDiffusion.Diffuse()

### DIFF
--- a/src/Dithering/ErrorDiffusionDithering.cs
+++ b/src/Dithering/ErrorDiffusionDithering.cs
@@ -1,4 +1,4 @@
-﻿/* Even more algorithms for dithering images using C#
+/* Even more algorithms for dithering images using C#
  * https://www.cyotek.com/blog/even-more-algorithms-for-dithering-images-using-csharp
  *
  * Copyright © 2015 Cyotek Ltd.
@@ -72,8 +72,8 @@ namespace Cyotek.Drawing.Imaging.ColorReduction
       int greenError;
 
       redError = original.R - transformed.R;
-      blueError = original.G - transformed.G;
-      greenError = original.B - transformed.B;
+      greenError = original.G - transformed.G;
+      blueError = original.B - transformed.B;
 
       for (int row = 0; row < _matrixHeight; row++)
       {


### PR DESCRIPTION
Before fix:
![before_fix](https://github.com/user-attachments/assets/5d46e44a-c4fb-4b72-909b-69922e5d4a8e)
After fix:
(The dithered image looks to have a pattern because of my screenshot software, that pattern is not there on my screen)
![after_fix](https://github.com/user-attachments/assets/f8c7758c-2df9-4ff7-97fc-4f890cba45f7)
